### PR TITLE
refactor: replace z by y in request format

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ GET Enter_name_of_the_index_here/_search
             "to": y
           },
           {
-            "from": z
+            "from": y
           }
         ]
       }


### PR DESCRIPTION
Under the **Range Aggregation** section, the query format uses the following range:
```json
{...
    "ranges": [
          {
            "to": x
          },
          {
            "from": x,
            "to": y
          },
          {
            "from": z
          }
        ]
}
```
This assumes that `x != y != z` and that the third range (`{"from": z}` starts from a value that's not a boundary of the previous range. However, the example that ensues uses `{"from": 50, "to": 200}` as the second range. Then, `{"from": 200}` is the last range. This needs to be more consistent and could lead to clarity.